### PR TITLE
Check for user hybrid workers as system ones might be registered also.

### DIFF
--- a/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
+++ b/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
@@ -313,8 +313,8 @@ function TestRegRegistry
 {
     $Reg = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker
     if ($null -eq $Reg) {
-        #newer version
-        Get-Item -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker\*\* | 
+        #newer version. Check for user registered hybrid workers.
+        $Reg = Get-Item -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker\*\* | 
             ForEach-Object -Process {
                 if (Get-ChildItem -Path $_.PSPath |
                     Where-Object -FilterScript {
@@ -325,7 +325,16 @@ function TestRegRegistry
                 }
             }
         }
-    $Reg
+    if ($Reg -ne $null)
+    {
+        # User hybrid worker is registered
+        $true
+    }
+    else
+    {
+        # User hybrid worker is not registered
+        $false
+    }
 }
 
 <#

--- a/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
+++ b/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
@@ -311,7 +311,21 @@ function TestRegModule
 #>
 function TestRegRegistry
 {
-    Test-Path -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker
+    $Reg = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker
+    if ($null -eq $Reg) {
+        #newer version
+        Get-Item -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker\*\* | 
+            ForEach-Object -Process {
+                if (Get-ChildItem -Path $_.PSPath |
+                    Where-Object -FilterScript {
+                        $_.PSChildName -eq 'User'
+                    }
+                ) {
+                    $_.PSChildName
+                }
+            }
+        }
+    $Reg
 }
 
 <#


### PR DESCRIPTION
Hi Ben,
Since we use hybrid workers for Update Management also, it can appear that the hybrid worker is installed when it is not since only the system one is. I updated the TestRegRegisty function to only return a value if it finds the hybrid worker form a user registration and not a system one. Let me know if this makes sense to you as I refer to your PowerShell module in an example ARM template I use on https://github.com/azureautomation/automation-packs/blob/master/managed-vm/dsc-configurations/HybridWorkerConfig.ps1
Thanks,
Eamon