### PR TITLE
Bennbatt8112 patch 1

### DIFF
--- a/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
+++ b/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
@@ -314,10 +314,10 @@ function TestRegRegistry
     $testResult = $false
 
     $reg = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker -ErrorAction SilentlyContinue
-    if ($null -ne $reg)
+    if ($null -eq $reg)
     {
         #newer version. Check for user registered hybrid workers.
-        $regCheck = Get-Item -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker\*\* | 
+        $regCheck = Get-Item -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker\*\* -ErrorAction SilentlyContinue | 
             ForEach-Object -Process {
                 if (Get-ChildItem -Path $_.PSPath |
                     Where-Object -FilterScript {

--- a/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
+++ b/DSCResources/MSFT_HybridRunbookWorker/MSFT_HybridRunbookWorker.psm1
@@ -314,7 +314,7 @@ function TestRegRegistry
     $testResult = $false
 
     $reg = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker -ErrorAction SilentlyContinue
-    if ($null -eq $reg)
+    if ($null -ne $reg)
     {
         #newer version. Check for user registered hybrid workers.
         $regCheck = Get-Item -Path HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker\*\* | 


### PR DESCRIPTION
Hey Ben,

Eamon and I discussed the logic of this for a bit.
I tried registering my Hybrid Runbook Worker and was finding that I kept receiving an error "cannot find path "HKLM:\SOFTWARE\Microsoft\HybridRunbookWorker" which blocked the registration since I didn't have a System Worker.

Haven't done a rigorous test quite yet.. will explore later.
LMK what you think.
